### PR TITLE
fix wrong bower directory path

### DIFF
--- a/src/.bowerrc
+++ b/src/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "js/bower_components"
+  "directory": "resources/bower_components"
 }


### PR DESCRIPTION
gulp expects our bower_components/ directory inside resources/ not js/
